### PR TITLE
ci: add Depot CI devcontainer scenario testing

### DIFF
--- a/.depot/workflows/devcontainer.yml
+++ b/.depot/workflows/devcontainer.yml
@@ -1,0 +1,155 @@
+# Depot CI — devcontainer scenario testing for dev-env.
+#
+# Grown one rung at a time (see NEXT.md "## CI"). Each rung exercises the real
+# generate -> build -> up flow on a Depot runner, proving the host-adaptive
+# init scripts work from a fresh checkout. Iterate without pushing:
+#
+#   depot ci run --workflow .depot/workflows/devcontainer.yml
+#
+# depot ci run uploads uncommitted changes as a patch, so a dirty working tree
+# is included in the run — keep docker/Dockerfile clean before running.
+#
+# GitHub Actions syntax; Depot CI executes it on managed runners.
+name: devcontainer
+
+on:
+  # Build every push except work-in-progress branches, plus every pull
+  # request. The per-job `if` guard drops the redundant same-repo PR run.
+  push:
+    branches-ignore:
+      - '**-wip'
+  pull_request:
+  # depot ci run drives on-demand iteration from a feature branch — Depot only
+  # registers the push/pull_request triggers once the workflow is on the
+  # default branch — so keep an explicit manual trigger too.
+  workflow_dispatch:
+
+jobs:
+  build:
+    # Rung 2 — generate, then build, from a fresh checkout.
+    #
+    # A clean checkout carries the committed devcontainer.json but not the
+    # gitignored .devcontainer/Dockerfile. `devcontainer build` does not run
+    # initializeCommand (only `up`/`create` do), so init.js must run first to
+    # write the Dockerfile and merge the overlay.
+    runs-on: depot-ubuntu-24.04
+    # A same-repo pull request was already built by its push event; only run the
+    # pull_request build when it comes from a different repository (a fork).
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+    env:
+      # Point npm/npx at the mounted cache disk so the devcontainer CLI (and the
+      # resolved npx tree) persist across runs, independent of $HOME.
+      NPM_CONFIG_CACHE: /mnt/npm-cache
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate devcontainer files
+        run: node .devcontainer/init.js
+
+      # Persist the npm store (the @devcontainers/cli download and resolved npx
+      # tree) on a durable Depot CI cache disk. Unlike actions/cache, cache-mount
+      # is keyed by an org-global name, not a branch/tag ref, so it works under
+      # ref-less `depot ci run`; write-lock lets this job populate the disk.
+      - name: Mount npm cache disk
+        uses: depot/cache-mount@v1
+        with:
+          name: dev-env-npm-cache
+          path: /mnt/npm-cache
+          write-lock: /mnt/npm-cache
+          debug: true
+
+      # Caching signal: a cold disk is empty here, a warm one already holds the
+      # CLI — so the size printed before the build should jump between passes.
+      - name: Report npm cache before build
+        run: du -sh /mnt/npm-cache
+
+      # Pinned to the CLI version verified locally (0.87.0).
+      - name: Build devcontainer image
+        run: npx -y @devcontainers/cli@0.87.0 build --workspace-folder .
+
+      - name: Report npm cache after build
+        run: du -sh /mnt/npm-cache
+
+      # Rung 3 — start the container. Unlike build, `up` runs initializeCommand
+      # itself (init.js -> init.sh), so it re-generates the files and then
+      # brings the container up: the first rung to exercise the bind mounts
+      # (.claude, .claude.json, cache home, gnupg-absent) and the privileged
+      # runArgs (cap-adds, unconfined apparmor/seccomp) on a Depot runner.
+      - name: Start devcontainer
+        run: npx -y @devcontainers/cli@0.87.0 up --workspace-folder .
+
+      # Rung 4 — exec a probe inside the started container. The probe lives in
+      # the workspace, so it is only reachable here if the workspace bind
+      # resolved; it then verifies the container user, the entrypoint's
+      # environment, and the host-config binds from within.
+      - name: Probe inside container
+        run: npx -y @devcontainers/cli@0.87.0 exec --workspace-folder . sh .devcontainer/probe.sh
+
+  devcontainer-json:
+    # Rung 6 (scenario axis B) — devcontainer.json present / missing / empty.
+    # The merged guard is init.sh:270 `[ -s "$F" ] || die "devcontainer.json
+    # not found or empty."`, so `-s` fails for both a missing and an empty file
+    # (there is no template path). A present file must let init succeed; a
+    # missing or empty one must die *via that guard*, not some unrelated crash.
+    # Each case declares its expected outcome and the assert step enforces it.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - case: present
+            expect: success
+          - case: missing
+            expect: die
+          - case: empty
+            expect: die
+    runs-on: depot-ubuntu-24.04
+    # A same-repo pull request was already built by its push event; only run the
+    # pull_request build when it comes from a different repository (a fork).
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Set up the ${{ matrix.case }} devcontainer.json
+        run: |
+          F=.devcontainer/devcontainer.json
+          case "${{ matrix.case }}" in
+            present) ;;            # committed file, already in generated form
+            missing) rm -f "$F" ;;
+            empty)   : > "$F" ;;
+          esac
+
+      - name: Assert init ${{ matrix.expect }} on a ${{ matrix.case }} file
+        run: |
+          set +e
+          err=$(node .devcontainer/init.js 2>&1)
+          code=$?
+          set -e
+          echo "$err"
+          case "${{ matrix.expect }}" in
+            success)
+              if [ "$code" -ne 0 ]; then
+                echo "FAIL: init.js exited $code, expected success"
+                exit 1
+              fi
+              echo "PASS: init.js succeeded on a present devcontainer.json" ;;
+            die)
+              if [ "$code" -eq 0 ]; then
+                echo "FAIL: init.js exited 0, expected a guard die"
+                exit 1
+              fi
+              case "$err" in
+                *"devcontainer.json not found or empty"*)
+                  echo "PASS: init.js died via the guard (exit $code)" ;;
+                *)
+                  echo "FAIL: init.js exited $code but not via the guard"
+                  exit 1 ;;
+              esac ;;
+          esac

--- a/.devcontainer/probe.sh
+++ b/.devcontainer/probe.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# In-container verification probe for the dev-env devcontainer.
+#
+# Run inside the started container via `devcontainer exec`. Its mere presence
+# here proves the workspace bind mount resolved: a fresh checkout's copy of
+# this file is only visible to the container through that mount. The checks
+# below then confirm the container user, the environment the entrypoint sets,
+# and that the host-config binds are live from within — not merely that the
+# mounts were requested at `up` time.
+set -eu
+
+fail=0
+
+# assert_eq compares an observed value against the expected one, recording a
+# failure without aborting so every check reports before the probe exits.
+assert_eq() {
+	desc=$1
+	want=$2
+	got=$3
+	if [ "$got" = "$want" ]; then
+		printf 'PASS  %s: %s\n' "$desc" "$got"
+	else
+		printf 'FAIL  %s: want %s, got %s\n' "$desc" "$want" "$got"
+		fail=1
+	fi
+}
+
+# assert_test evaluates a `test` expression (operator + operands) and records a
+# failure if it does not hold.
+assert_test() {
+	desc=$1
+	shift
+	if [ "$@" ]; then
+		printf 'PASS  %s\n' "$desc"
+	else
+		printf 'FAIL  %s\n' "$desc"
+		fail=1
+	fi
+}
+
+# assert_mount records a failure unless the path is its own mountpoint. A bind
+# is only proven live this way: the target existing could be the underlying
+# sandboxed-home copy, but a distinct mountpoint can only be the bind.
+assert_mount() {
+	desc=$1
+	path=$2
+	if findmnt "$path" >/dev/null 2>&1; then
+		printf 'PASS  %s bind at %s\n' "$desc" "$path"
+	else
+		printf 'FAIL  %s: %s is not a mountpoint\n' "$desc" "$path"
+		fail=1
+	fi
+}
+
+# note reports a host-dependent value without asserting on it.
+note() {
+	printf 'note  %s: %s\n' "$1" "$2"
+}
+
+# present_absent echoes present when the path exists, absent otherwise.
+present_absent() {
+	if [ -f "$1" ]; then
+		echo present
+	else
+		echo absent
+	fi
+}
+
+echo '== identity =='
+assert_eq 'container user' "$(whoami)" 'runner'
+note 'id' "$(id)"
+
+echo '== environment (entrypoint) =='
+note 'pwd' "$(pwd)"
+note 'WS' "${WS:-<unset>}"
+note 'CURDIR' "${CURDIR:-<unset>}"
+
+echo '== workspace bind =='
+# This script runs, so the workspace bind already resolved; confirm the repo's
+# own marker files are readable through it.
+assert_test 'devcontainer.json readable' -r .devcontainer/devcontainer.json
+assert_test 'this probe readable' -r .devcontainer/probe.sh
+
+echo '== host-config binds =='
+assert_test '.claude directory present' -d "$HOME/.claude"
+assert_test '.claude.json file present' -f "$HOME/.claude.json"
+
+echo '== bind mounts live =='
+# Assert each expected target is its own mountpoint (the whole point of rung 4:
+# the binds are live from within, not merely requested at `up` time).
+assert_mount 'workspace' "${WS:-$PWD}"
+assert_mount 'sandboxed home' "$HOME"
+assert_mount '.claude' "$HOME/.claude"
+assert_mount '.claude.json' "$HOME/.claude.json"
+# Full mount table for the record (no type filter: bind mounts inherit the
+# underlying fs type, so `findmnt -t bind` would match nothing).
+findmnt || note 'findmnt' 'unavailable'
+
+echo '== host alias (informational) =='
+# host.docker.internal depends on the runner's bridge; report, do not assert.
+note 'host.docker.internal' "$(getent hosts host.docker.internal || echo '<unresolved>')"
+note 'ollama profile' "$(present_absent /etc/profile.d/ollama.sh)"
+
+if [ "$fail" -ne 0 ]; then
+	echo 'probe: FAILURES reported above'
+	exit 1
+fi
+echo 'probe: all checks passed'


### PR DESCRIPTION
Integration-test the devcontainer generate → build → up → exec flow on Depot
CI from a fresh checkout, proving the host-adaptive init scripts
(init.js/init.sh) work without the maintainer's local state — on a CI runner
the generated Dockerfile runs the init for user "runner", not "amery".

## Workflow

`.depot/workflows/devcontainer.yml` (GitHub Actions syntax, on Depot's managed
Linux runners) has two jobs:

- **build** — init.js → devcontainer build → up → exec. `up` runs
  initializeCommand itself and brings the container up, exercising the bind
  mounts and the privileged runArgs; the exec runs `.devcontainer/probe.sh`
  inside it. The npm store persists on a Depot cache-mount disk.
- **devcontainer-json** — a present/missing/empty matrix over the
  `[ -s "$F" ] || die` guard, each case asserting its declared outcome.

`.devcontainer/probe.sh` is the in-container counterpart to the host-side
test-paths.js: its presence proves the workspace bind resolved, then it
asserts the container user, the entrypoint environment, and each host-config
bind as a live mountpoint.

## Triggers

Runs on push (except `**-wip` branches) and pull request, plus
workflow_dispatch for on-demand `depot ci run`. A per-job guard skips the
redundant same-repo pull request run — so on this same-repo PR the jobs are
expected to skip; the push is what builds them. Depot only registers the
push/pull_request triggers once the workflow reaches the default branch, so
merging this is the step that activates them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for the development container setup.
  * Added environment checks covering container identity, workspace mounting, configuration files, and expected mount points.
  * Added scenario testing for missing or empty container configuration.

* **Bug Fixes**
  * Improved detection and reporting of invalid or incomplete development container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->